### PR TITLE
Fix `ScaffolderFieldExtensions` deprecation 

### DIFF
--- a/packages/dynamic-pick-extension/README.md
+++ b/packages/dynamic-pick-extension/README.md
@@ -14,7 +14,7 @@ Add the import to your `packages/app/src/App.tsx` on the frontend package of you
 
 ```js
 import { DynamicPickFieldExtension } from '@premise/plugin-dynamic-pick-extension';
-import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder';
+import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
 ```
 
 Then add the imported field extension as a child of `ScaffolderFieldExtensions` inside `Route`
@@ -27,7 +27,7 @@ Then add the imported field extension as a child of `ScaffolderFieldExtensions` 
 </Route>
 ```
 
-You should not see the custom filed `DynamicPickExtension` clicking "Custom field explored" here `http://localhost:3000/create/edit`.
+You should now see the custom filed `DynamicPickExtension` clicking "Custom field explored" here `http://localhost:3000/create/edit`.
 
 ## Usage
 To use the extension on a [Backstage Template Action](https://backstage.io/docs/features/software-templates/writing-templates) just add the `ui-field` and `ui-options` fields to the parameter

--- a/packages/dynamic-pick-extension/package.json
+++ b/packages/dynamic-pick-extension/package.json
@@ -25,10 +25,12 @@
     "@backstage/core-components": "^0.12.4",
     "@backstage/core-plugin-api": "^1.4.0",
     "@backstage/plugin-scaffolder": "^1.11.0",
+    "@backstage/plugin-scaffolder-react": "^1.1.0",
     "@backstage/theme": "^0.2.17",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.57",
+    "zod": "^3.18.0",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {

--- a/packages/dynamic-pick-extension/src/components/DynamicPickExtension.tsx
+++ b/packages/dynamic-pick-extension/src/components/DynamicPickExtension.tsx
@@ -51,7 +51,7 @@ export const DynamicPickExtension = ({
       id={idSchema?.$id}
       loading={loading}
       value={formData ?? null}
-      renderInput={(params) =>
+      renderInput={(params) => (
         <TextField
           {...params}
           label={title}
@@ -60,7 +60,7 @@ export const DynamicPickExtension = ({
           error={rawErrors?.length > 0 && !formData}
           helperText={description}
         />
-      }
+      )}
       options={formDataOptions}
       onChange={(_, value) => onChange(value)}
       getOptionSelected={(option, value) => option === value}


### PR DESCRIPTION
`ScaffolderFieldExtensions` has been moved into `@backstage/plugin-scaffolder-react`. 