### PR TITLE
Improve docs on the custom providers for backend plugin

### DIFF
--- a/packages/form-data-backend/README.md
+++ b/packages/form-data-backend/README.md
@@ -35,9 +35,14 @@ export default async function createPlugin(
 }
 ```
 
-Create a `providers` folder under `packages/backend/src` containing all of your custom providers for example:
+Create a `providers` folder under `packages/backend/src` containing all of your custom providers:
+`packages/backend/src/providers/index.ts`
+```ts
+# Add here other custom providers
+export * from './example.ts';
+```
 
-`example.ts`
+`packages/backend/src/providers/example.ts`
 ```ts
 import express from 'express';
 import Router from 'express-promise-router';


### PR DESCRIPTION
Taking the suggestion from this PR: https://github.com/premisedata/dynamic-data-form-extension/pull/19 I think is better to show people the advantage of adding a `index.ts` in the `providers` so you can have multiple providers splitted into its own file.